### PR TITLE
Added example using OS::Heat::SoftwareDeployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ repository with a common structure:
 │   ├── some_example.yaml
 │   ├── environment_example.yaml
 │   │
-│   ├── scripts/
+│   ├── files/
 │   │   ├── some_script.sh
 │   │
 │   ├── resources/

--- a/SoftwareDeployment/README.md
+++ b/SoftwareDeployment/README.md
@@ -1,0 +1,54 @@
+# Using OS::Heat::SoftwareDeployment Resources
+
+This is an example HEAT Template that deploys a vanilla instance and
+automatically installs and configures the pre-req os-collect-config 
+tools on the instance in order to make use of OS::Heat::SoftwareConfig / 
+OS::Heat::SoftwareDeployment and associated HEAT resources.
+
+To deploy this example, customise the environment_example.yaml file with your
+own SSH Keypair and the Network name to deploy onto and run:
+```
+> openstack stack create -t software_deployment.yaml -e environment_example.yaml --wait deploy-demo
+2016-12-07 12:03:55 [deploy-demo]: CREATE_IN_PROGRESS  Stack CREATE started
+2016-12-07 12:03:55 [deploy-demo.ssh_ext_secgroup]: CREATE_IN_PROGRESS  state changed
+2016-12-07 12:03:56 [deploy-demo.software_config]: CREATE_IN_PROGRESS  state changed
+2016-12-07 12:03:56 [deploy-demo.config_agent]: CREATE_IN_PROGRESS  state changed
+2016-12-07 12:03:56 [deploy-demo.ssh_ext_secgroup]: CREATE_COMPLETE  state changed
+2016-12-07 12:03:56 [deploy-demo.software_config]: CREATE_COMPLETE  state changed
+2016-12-07 12:03:58 [deploy-demo.config_agent]: CREATE_COMPLETE  state changed
+2016-12-07 12:03:59 [deploy-demo.server]: CREATE_IN_PROGRESS  state changed
+2016-12-07 12:04:09 [deploy-demo.server]: CREATE_COMPLETE  state changed
+2016-12-07 12:04:09 [deploy-demo.deploy_config]: CREATE_IN_PROGRESS  state changed
+2016-12-07 12:07:35 [deploy-demo.deploy_config]: SIGNAL_IN_PROGRESS  Signal: deployment succeeded
+2016-12-07 12:07:35 [deploy-demo.deploy_config]: CREATE_COMPLETE  state changed
+2016-12-07 12:07:35 [deploy-demo]: CREATE_COMPLETE  Stack CREATE completed successfully
++---------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| Field               | Value
+
+                                                                                 |
++---------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| id                  | 9108ca32-0e0e-4852-ba5a-7151a29d9f66
+
+                                                                                 |
+| stack_name          | deploy-demo
+
+                                                                                 |
+| description         | This HEAT template demonstrates the creation of an instances and uses the OS::Heat::SoftwareConfig and OS::Heat::SoftwareDeployment resources to deploy software using os-collect-config tools. The template takes a vanilla OS deployment and automatically installs and configures os-collect-config in preparation for connecting to the HEAT engine. |
+|                     |
+
+                                                                                 |
+| creation_time       | 2016-12-07T12:03:55
+
+                                                                                 |
+| updated_time        | None
+
+                                                                                 |
+| stack_status        | CREATE_COMPLETE
+
+                                                                                 |
+| stack_status_reason | Stack CREATE completed successfully
+
+                                                                                 |
++---------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+```
+

--- a/SoftwareDeployment/README.md
+++ b/SoftwareDeployment/README.md
@@ -8,47 +8,29 @@ OS::Heat::SoftwareDeployment and associated HEAT resources.
 To deploy this example, customise the environment_example.yaml file with your
 own SSH Keypair and the Network name to deploy onto and run:
 ```
-> openstack stack create -t software_deployment.yaml -e environment_example.yaml --wait deploy-demo
-2016-12-07 12:03:55 [deploy-demo]: CREATE_IN_PROGRESS  Stack CREATE started
-2016-12-07 12:03:55 [deploy-demo.ssh_ext_secgroup]: CREATE_IN_PROGRESS  state changed
-2016-12-07 12:03:56 [deploy-demo.software_config]: CREATE_IN_PROGRESS  state changed
-2016-12-07 12:03:56 [deploy-demo.config_agent]: CREATE_IN_PROGRESS  state changed
-2016-12-07 12:03:56 [deploy-demo.ssh_ext_secgroup]: CREATE_COMPLETE  state changed
-2016-12-07 12:03:56 [deploy-demo.software_config]: CREATE_COMPLETE  state changed
-2016-12-07 12:03:58 [deploy-demo.config_agent]: CREATE_COMPLETE  state changed
-2016-12-07 12:03:59 [deploy-demo.server]: CREATE_IN_PROGRESS  state changed
-2016-12-07 12:04:09 [deploy-demo.server]: CREATE_COMPLETE  state changed
-2016-12-07 12:04:09 [deploy-demo.deploy_config]: CREATE_IN_PROGRESS  state changed
-2016-12-07 12:07:35 [deploy-demo.deploy_config]: SIGNAL_IN_PROGRESS  Signal: deployment succeeded
-2016-12-07 12:07:35 [deploy-demo.deploy_config]: CREATE_COMPLETE  state changed
-2016-12-07 12:07:35 [deploy-demo]: CREATE_COMPLETE  Stack CREATE completed successfully
-+---------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| Field               | Value
+> openstack stack update -t software_deployment.yaml -e environment_rob.yaml --wait deploy-demo -f yaml
+2016-12-07 12:41:58 [deploy-demo]: UPDATE_IN_PROGRESS  Stack UPDATE started
+2016-12-07 12:42:00 [deploy-demo.config]: UPDATE_IN_PROGRESS  state changed
+2016-12-07 12:42:01 [deploy-demo.config]: CREATE_IN_PROGRESS  state changed
+2016-12-07 12:42:01 [deploy-demo.config_agent]: UPDATE_IN_PROGRESS  state changed
+2016-12-07 12:42:02 [deploy-demo.config]: CREATE_COMPLETE  state changed
+2016-12-07 12:42:05 [deploy-demo.config_agent]: UPDATE_COMPLETE  state changed
+2016-12-07 12:42:05 [deploy-demo.deployment]: UPDATE_IN_PROGRESS  state changed
+2016-12-07 12:42:08 [deploy-demo.deployment]: SIGNAL_IN_PROGRESS  Signal: deployment succeeded
+2016-12-07 12:42:08 [deploy-demo.deployment]: UPDATE_COMPLETE  state changed
+2016-12-07 12:42:11 [deploy-demo]: UPDATE_COMPLETE  Stack UPDATE completed successfully
+id: 7bb3b89f-1e71-47c0-960a-e6c2a8ee0926
+stack_name: deploy-demo
+description: 'This HEAT template demonstrates the creation of an instances and uses
+  the OS::Heat::SoftwareConfig and OS::Heat::SoftwareDeployment resources to deploy
+  software using os-collect-config tools. The template takes a vanilla OS deployment
+  and automatically installs and configures os-collect-config in preparation for connecting
+  to the HEAT engine.
 
-                                                                                 |
-+---------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| id                  | 9108ca32-0e0e-4852-ba5a-7151a29d9f66
-
-                                                                                 |
-| stack_name          | deploy-demo
-
-                                                                                 |
-| description         | This HEAT template demonstrates the creation of an instances and uses the OS::Heat::SoftwareConfig and OS::Heat::SoftwareDeployment resources to deploy software using os-collect-config tools. The template takes a vanilla OS deployment and automatically installs and configures os-collect-config in preparation for connecting to the HEAT engine. |
-|                     |
-
-                                                                                 |
-| creation_time       | 2016-12-07T12:03:55
-
-                                                                                 |
-| updated_time        | None
-
-                                                                                 |
-| stack_status        | CREATE_COMPLETE
-
-                                                                                 |
-| stack_status_reason | Stack CREATE completed successfully
-
-                                                                                 |
-+---------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+  '
+creation_time: '2016-12-07T12:36:12'
+updated_time: '2016-12-07T12:41:58'
+stack_status: UPDATE_COMPLETE
+stack_status_reason: Stack UPDATE completed successfully
 ```
 

--- a/SoftwareDeployment/environment_example.yaml
+++ b/SoftwareDeployment/environment_example.yaml
@@ -1,0 +1,5 @@
+parameters:
+  flavor: t1.tiny
+  image: CentOS 7
+  key_name: MyKeyPair
+  network: Internal

--- a/SoftwareDeployment/environment_rob.yaml
+++ b/SoftwareDeployment/environment_rob.yaml
@@ -1,5 +1,0 @@
-parameters:
-  flavor: t1.tiny
-  image: CentOS 7
-  key_name: RobC
-  network: Internal

--- a/SoftwareDeployment/environment_rob.yaml
+++ b/SoftwareDeployment/environment_rob.yaml
@@ -1,0 +1,5 @@
+parameters:
+  flavor: t1.tiny
+  image: CentOS 7
+  key_name: RobC
+  network: Internal

--- a/SoftwareDeployment/files/deploy.sh
+++ b/SoftwareDeployment/files/deploy.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+#
+
+echo "Hello $firstname $lastname"

--- a/SoftwareDeployment/files/deploy.sh
+++ b/SoftwareDeployment/files/deploy.sh
@@ -2,3 +2,9 @@
 #
 
 echo "Hello $firstname $lastname"
+
+echo "Writing to /tmp/demo"
+echo "Hello $firstname $lastname" > /tmp/demo
+echo -n "The file /tmp/demo contains `cat /tmp/demo` for server $deploy_server_id during $deploy_action" > $heat_outputs_path.result
+echo "Written to /tmp/demo"
+echo "Output to stderr" 1>&2

--- a/SoftwareDeployment/resources/collect-config-setup/files/configure_config_agent.sh
+++ b/SoftwareDeployment/resources/collect-config-setup/files/configure_config_agent.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+set -eux
+
+# this file should be included in write_files section for the node
+#source /usr/local/share/openshift-on-openstack/common_functions.sh
+
+# on Atomic host os-collect-config runs inside a container which is
+# fetched&started in another step
+[ -e /run/ostree-booted ] && exit 0
+
+# os-apply-config templates directory
+oac_templates=/usr/libexec/os-apply-config/templates
+mkdir -p $oac_templates/etc
+
+# initial /etc/os-collect-config.conf
+cat <<EOF >/etc/os-collect-config.conf
+[DEFAULT]
+command = os-refresh-config
+EOF
+
+# template for building os-collect-config.conf for polling heat
+cat <<EOF >$oac_templates/etc/os-collect-config.conf
+[DEFAULT]
+{{^os-collect-config.command}}
+command = os-refresh-config
+{{/os-collect-config.command}}
+{{#os-collect-config}}
+{{#command}}
+command = {{command}}
+{{/command}}
+{{#polling_interval}}
+polling_interval = {{polling_interval}}
+{{/polling_interval}}
+{{#cachedir}}
+cachedir = {{cachedir}}
+{{/cachedir}}
+{{#collectors}}
+collectors = {{.}}
+{{/collectors}}
+
+{{#cfn}}
+[cfn]
+{{#metadata_url}}
+metadata_url = {{metadata_url}}
+{{/metadata_url}}
+stack_name = {{stack_name}}
+secret_access_key = {{secret_access_key}}
+access_key_id = {{access_key_id}}
+path = {{path}}
+{{/cfn}}
+
+{{#heat}}
+[heat]
+auth_url = {{auth_url}}
+user_id = {{user_id}}
+password = {{password}}
+project_id = {{project_id}}
+stack_id = {{stack_id}}
+resource_name = {{resource_name}}
+{{/heat}}
+
+{{#request}}
+[request]
+{{#metadata_url}}
+metadata_url = {{metadata_url}}
+{{/metadata_url}}
+{{/request}}
+
+{{/os-collect-config}}
+EOF
+mkdir -p $oac_templates/var/run/heat-config
+
+# template for writing heat deployments data to a file
+echo "{{deployments}}" > $oac_templates/var/run/heat-config/heat-config
+
+# os-refresh-config scripts directory
+# This moves to /usr/libexec/os-refresh-config in later releases
+orc_scripts=/opt/stack/os-config-refresh
+for d in pre-configure.d configure.d migration.d post-configure.d; do
+    install -m 0755 -o root -g root -d $orc_scripts/$d
+done
+
+# os-refresh-config script for running os-apply-config
+cat <<EOF >$orc_scripts/configure.d/20-os-apply-config
+#!/bin/bash
+set -ue
+
+exec os-apply-config
+EOF
+chmod 700 $orc_scripts/configure.d/20-os-apply-config
+
+ln -s /usr/share/openstack-heat-templates/software-config/elements/heat-config/os-refresh-config/configure.d/55-heat-config $orc_scripts/configure.d/55-heat-config
+
+# config hook for shell scripts
+hooks_dir=/var/lib/heat-config/hooks
+mkdir -p $hooks_dir
+
+# install hook for configuring with shell scripts
+ln -s /usr/share/openstack-heat-templates/software-config/heat-container-agent/scripts/hooks/script $hooks_dir/script
+
+# install heat-config-notify command
+ln -s /usr/share/openstack-heat-templates/software-config/elements/heat-config/bin/heat-config-notify /usr/bin/heat-config-notify
+
+# run once to write out /etc/os-collect-config.conf
+# use notify_failure from common_functions.sh to
+# make sure cloud-init reports failure
+os-collect-config --one-time --debug #||
+    #notify_failure "failed to run os-collect-config"
+
+# check that a valid metadata_url was set
+curl "$(grep metadata_url /etc/os-collect-config.conf |sed 's/metadata_url = //')" #||
+    #notify_failure "failed to connect to os-collect-config metadata_url"
+
+cat /etc/os-collect-config.conf

--- a/SoftwareDeployment/resources/collect-config-setup/files/install_config_agent_yum.sh
+++ b/SoftwareDeployment/resources/collect-config-setup/files/install_config_agent_yum.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -eux
+
+# on Atomic host os-collect-config runs inside a container which is
+# fetched&started in another step
+[ -e /run/ostree-booted ] && exit 0
+
+if ! yum info os-collect-config; then
+    # if os-collect-config package is not available, first check if
+    # the repo is available but disabled, otherwise install the package
+    # from epel
+    if yum repolist disabled|grep rhel-7-server-openstack-8-director-rpms; then
+        subscription-manager repos --enable="rhel-7-server-openstack-8-director-rpms"
+        subscription-manager repos --enable="rhel-7-server-openstack-8-rpms"
+    else
+        yum -y install centos-release-openstack-liberty
+    fi
+fi
+yum -y install os-collect-config python-zaqarclient os-refresh-config os-apply-config openstack-heat-templates python-oslo-log python-psutil
+#yum-config-manager --disable 'epel*'

--- a/SoftwareDeployment/resources/collect-config-setup/files/start_config_agent.sh
+++ b/SoftwareDeployment/resources/collect-config-setup/files/start_config_agent.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -eux
+
+# on Atomic host os-collect-config runs inside a container which is
+# fetched&started in another step
+[ -e /run/ostree-booted ] && exit 0
+
+# enable and start service to poll for deployment changes
+systemctl enable os-collect-config
+systemctl start --no-block os-collect-config

--- a/SoftwareDeployment/resources/collect-config-setup/install_config_agent_centos_yum.yaml
+++ b/SoftwareDeployment/resources/collect-config-setup/install_config_agent_centos_yum.yaml
@@ -1,0 +1,34 @@
+heat_template_version: 2014-10-16
+
+resources:
+
+  install_config_agent_yum:
+    type: "OS::Heat::SoftwareConfig"
+    properties:
+      group: ungrouped
+      config: {get_file: files/install_config_agent_yum.sh}
+
+  configure_config_agent:
+    type: "OS::Heat::SoftwareConfig"
+    properties:
+      group: ungrouped
+      config:
+        get_file: files/configure_config_agent.sh
+
+  start_config_agent:
+    type: "OS::Heat::SoftwareConfig"
+    properties:
+      group: ungrouped
+      config: {get_file: files/start_config_agent.sh}
+
+  install_config_agent:
+    type: "OS::Heat::MultipartMime"
+    properties:
+      parts:
+      - config: {get_resource: install_config_agent_yum}
+      - config: {get_resource: configure_config_agent}
+      - config: {get_resource: start_config_agent}
+
+outputs:
+  config:
+    value: {get_resource: install_config_agent}

--- a/SoftwareDeployment/software_deployment.yaml
+++ b/SoftwareDeployment/software_deployment.yaml
@@ -36,7 +36,6 @@ resources:
   ssh_ext_secgroup:
     type: OS::Neutron::SecurityGroup
     properties:
-      name: ssh_ext_secgroup
       rules:
         - protocol: tcp
           remote_ip_prefix: 0.0.0.0/0
@@ -48,7 +47,7 @@ resources:
   server:
     type: OS::Nova::Server
     properties:
-      name: demo01
+      name: deploydemo
       flavor: { get_param: flavor }
       image: { get_param: image }
       key_name: { get_param: key_name }
@@ -63,7 +62,7 @@ resources:
   config_agent:
     type: resources/collect-config-setup/install_config_agent_centos_yum.yaml
 
-  software_config:
+  config:
     type: OS::Heat::SoftwareConfig
     properties:
       group: script
@@ -74,11 +73,11 @@ resources:
       - name: result
       config: { get_file: 'files/deploy.sh' }
 
-  deploy_config:
+  deployment:
     type: OS::Heat::SoftwareDeployment
     properties:
       config:
-        get_resource: software_config
+        get_resource: config
       server:
         get_resource: server
       input_values:
@@ -86,7 +85,15 @@ resources:
         lastname: User
 
 outputs:
-  deploy_output:
-    description: Stdout returned from deploying the config to the server
+  result:
     value:
-      get_attr: [ deploy_config, deploy_stdout ]
+      get_attr: [deployment, result]
+  stdout:
+    value:
+      get_attr: [deployment, deploy_stdout]
+  stderr:
+    value:
+      get_attr: [deployment, deploy_stderr]
+  status_code:
+    value:
+      get_attr: [deployment, deploy_status_code]

--- a/SoftwareDeployment/software_deployment.yaml
+++ b/SoftwareDeployment/software_deployment.yaml
@@ -1,0 +1,92 @@
+heat_template_version: 2015-10-15
+
+description: >
+   This HEAT template demonstrates the creation of an instances and uses the
+   OS::Heat::SoftwareConfig and OS::Heat::SoftwareDeployment resources to
+   deploy software using os-collect-config tools. The template takes a vanilla
+   OS deployment and automatically installs and configures os-collect-config
+   in preparation for connecting to the HEAT engine.
+
+parameters:
+  key_name:
+    type: string
+    description: SSH Key Pair
+    constraints:
+      - custom_constraint: nova.keypair
+  flavor:
+    type: string
+    description: Flavor to use for the migration server
+    default: t1.small
+    constraints:
+      - custom_constraint: nova.flavor
+  image:
+    type: string
+    description: Select vCloudTransfer for a CentOS instance with ovftool installed
+    default: "vCloudTransfer"
+    constraints:
+      - custom_constraint: glance.image
+  network:
+    type: string
+    description: Name of the network to create the VM on
+    default: Internal
+    constraints:
+      - custom_constraint: neutron.network
+
+resources:
+  ssh_ext_secgroup:
+    type: OS::Neutron::SecurityGroup
+    properties:
+      name: ssh_ext_secgroup
+      rules:
+        - protocol: tcp
+          remote_ip_prefix: 0.0.0.0/0
+          port_range_min: 22
+          port_range_max: 22
+        - protocol: icmp
+          remote_ip_prefix: 0.0.0.0/0
+
+  server:
+    type: OS::Nova::Server
+    properties:
+      name: demo01
+      flavor: { get_param: flavor }
+      image: { get_param: image }
+      key_name: { get_param: key_name }
+      networks:
+        - network: { get_param: network }
+      security_groups:
+        - { get_resource: ssh_ext_secgroup }
+      user_data_format: SOFTWARE_CONFIG
+      user_data: { get_attr: [config_agent, config] }
+
+  # Install, configure and enable the Heat configuration agent
+  config_agent:
+    type: resources/collect-config-setup/install_config_agent_centos_yum.yaml
+
+  software_config:
+    type: OS::Heat::SoftwareConfig
+    properties:
+      group: script
+      inputs:
+      - name: firstname
+      - name: lastname
+      outputs:
+      - name: result
+      config: { get_file: 'files/deploy.sh' }
+
+  deploy_config:
+    type: OS::Heat::SoftwareDeployment
+    properties:
+      config:
+        get_resource: software_config
+      server:
+        get_resource: server
+      input_values:
+        firstname: Demo
+        lastname: User
+
+outputs:
+  deploy_output:
+    description: Stdout returned from deploying the config to the server
+    value:
+      get_attr: [ deploy_config, deploy_stdout ]


### PR DESCRIPTION
This is an example of automatically deploying the os-collect-config tools onto a vanilla instance and subsequently using the OS::Heat:SoftwareConfig and OS::Heat::SoftwareDeployment resources.